### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 fantasy_basketball
 ==================
 
-.. image:: https://pypip.in/v/Fantasy_Basketball/badge.png
+.. image:: https://img.shields.io/pypi/v/Fantasy_Basketball.svg
    :target: https://pypi.python.org/pypi/Fantasy_Basketball
    :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fantasy-basketball))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fantasy-basketball`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.